### PR TITLE
Benchmark results and fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test vtest deps tidy
+.PHONY: test vtest deps tidy bench
 
 all:
 
@@ -13,3 +13,6 @@ deps:
 
 tidy:
 	go mod tidy
+
+bench:
+	go test -bench=. -count 1 -run=^# -benchtime=2s ./...

--- a/enrich.go
+++ b/enrich.go
@@ -8,13 +8,11 @@ func (m *Metrics) enrich(typeName string, key string, labels []Label) (bool, []s
 	if m.cfg.EnableTypePrefix {
 		keys = insert(0, typeName, keys)
 	}
-	if m.cfg.ServiceName != "" {
-		if m.cfg.EnableServiceLabel {
-			labels = append(labels, Label{"service", m.cfg.ServiceName})
-		} else {
-			keys = insert(0, m.cfg.ServiceName, keys)
-		}
+	if m.cfg.ServiceName != "" && m.cfg.EnableServiceLabel {
+		labels = append(labels, Label{"service", m.cfg.ServiceName})
 	}
+	labels = append(labels, m.cfg.BaseLabels...)
+
 	allowed, labelsFiltered := m.allowMetric(keys, labels)
 
 	return allowed, keys, labelsFiltered

--- a/persisted.go
+++ b/persisted.go
@@ -6,6 +6,10 @@ import (
 	"time"
 )
 
+// A PersistentGauge maintains an observed value internally and publish the last
+// seen value on the publishing interval. The behavior is the same as using the
+// SetGauge method, however instead of each call posting a value to the sink and
+// the sink (e.g. agent) keeping the last value, this happens before the sink.
 type PersistentGauge interface {
 	Stop()
 	Set(val int64) int64
@@ -51,6 +55,9 @@ func (p *persistentGauge) report() {
 	p.gauge.Set(float64(curr))
 }
 
+// An AggregatedCounter can be useful for extremely hot-path metric instrumentation. It aggregates the total
+// increment delta internally and publishes the current delta on each report interval. Unlike the PersistentGauge,
+// an AggregatedCounter will reset its value to zero on each reporting interval.
 type AggregatedCounter interface {
 	Stop()
 	Incr(delta int64)

--- a/start.go
+++ b/start.go
@@ -12,7 +12,7 @@ import (
 
 // Config is used to configure metrics settings
 type Config struct {
-	ServiceName          string        // Prefixed with keys to separate services
+	ServiceName          string        // Name of service, added to labels if EnableServiceLabel is set
 	HostName             string        // Hostname to use. If not provided and EnableHostname, it will be os.Hostname
 	EnableHostnameLabel  bool          // Enable adding hostname to labels
 	EnableServiceLabel   bool          // Enable adding service to labels
@@ -22,7 +22,7 @@ type Config struct {
 	ProfileInterval      time.Duration // Interval to profile runtime metrics
 	PersistentInterval   time.Duration // Interval to publish persisted metrics
 
-	BaseLabels []Label // A set of base labels applied to all measurements
+	BaseLabels []Label // Default labels applied to all measurements
 
 	AllowedPrefixes []string // A list of metric prefixes to allow, with '.' as the separator
 	BlockedPrefixes []string // A list of metric prefixes to block, with '.' as the separator
@@ -145,6 +145,7 @@ func L(name string, value string) Label {
 	return Label{Name: name, Value: value}
 }
 
+// StatValue defines the allowed values for the simple interface
 type StatValue interface {
 	int | int8 | int32 | int64 | float32 | float64
 }

--- a/start.go
+++ b/start.go
@@ -154,46 +154,56 @@ type StatValue interface {
 // Proxy all the methods to the globalMetrics instance
 //
 
+// SetGauge records the current observed value
 func SetGauge[V StatValue](key string, val V, labels ...Label) {
 	currMetrics().SetGauge(key, float64(val), labels...)
 }
 
+// Incr increments a counter
 func Incr[V StatValue](key string, val V, labels ...Label) {
 	currMetrics().Incr(key, float64(val), labels...)
 }
 
+// Sample records an observation in a histogram
 func Sample[V StatValue](key string, val V, labels ...Label) {
 	currMetrics().Sample(key, float64(val), labels...)
 }
 
+// MeasureSince records the time elapsed since an event, often as a histogram
 func MeasureSince(key string, start time.Time, labels ...Label) {
 	currMetrics().MeasureSince(key, start, labels...)
 }
 
+// Observe records an observation as part of a distribution
 func Observe[V StatValue](key string, val V, labels ...Label) {
 	currMetrics().Observe(key, float64(val), labels...)
 }
 
 //
-// memomized versions
+// Memoized versions
 //
 
+// NewGauge creates a memoized gauge
 func NewGauge(key string, labels ...Label) Gauge {
 	return currMetrics().NewGauge(key, labels...)
 }
 
+// NewCounter creates a memoized counter
 func NewCounter(key string, labels ...Label) Counter {
 	return currMetrics().NewCounter(key, labels...)
 }
 
+// NewTimer creates a memoized timer
 func NewTimer(key string, labels ...Label) Timer {
 	return currMetrics().NewTimer(key, labels...)
 }
 
+// NewHistogram creates a memoized histogram
 func NewHistogram(key string, labels ...Label) Histogram {
 	return currMetrics().NewHistogram(key, labels...)
 }
 
+// NewDistribution creates a memoized histogram
 func NewDistribution(key string, labels ...Label) Distribution {
 	return currMetrics().NewDistribution(key, labels...)
 }


### PR DESCRIPTION
Adds benchmark results, fixes base labels and removes service name metric prefixing (preferred to do via labels).